### PR TITLE
Update treetagger_builder to ubuntu:20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # temporary image
-FROM ubuntu:19.04 AS treetagger_builder
+FROM ubuntu:20.04 AS treetagger_builder
 
 # TreeTagger version
 ARG VERSION=3.2.2


### PR DESCRIPTION
First of all, thanks for putting this together. It made it a lot easier for me to get tree-tagger up and running. 

Building the docker image with Ubuntu 19.04 as a base fails because some links don't work anymore and `apt-get` fails.
A switch to a newer base image is necessary since Ubuntu 19.04 is end-of-life.

Ubuntu 20.04 is a LTS release and will be supported until 2030. Non LTS releases expire after 9 months and should only be used as a base image if they contain some newer package versions that are not available in the previous LTS release.